### PR TITLE
Debug game initialization logic

### DIFF
--- a/src/js/core/engine/gameLoop.js
+++ b/src/js/core/engine/gameLoop.js
@@ -23,8 +23,23 @@ export class GameLoop {
     const deltaTime = now - this.lastTime;
     this.lastTime = now;
     this.lastDeltaTime = deltaTime; // Store for use by particle system
-    this.updateFn(deltaTime);
-    this.renderFn();
+    try {
+      // Execute update and render. Any uncaught error here would previously
+      // break the rAF chain without a helpful stack trace, making the game
+      // appear to freeze silently. Wrapping in try/catch lets us surface the
+      // error while halting the loop gracefully.
+      this.updateFn(deltaTime);
+      this.renderFn();
+    } catch (error) {
+      console.error('❌ Unhandled error inside GameLoop:', error);
+      // Stop the loop so we don\'t spam errors each frame
+      this.stop();
+      // Bubble up so global handlers / error trackers can react
+      if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+        window.dispatchEvent(new CustomEvent('GameLoopError', { detail: error }));
+      }
+      return; // Exit early – don\'t queue another frame
+    }
     requestAnimationFrame(() => this._loop());
   }
 }


### PR DESCRIPTION
Wrap game loop update and render calls in a try/catch block to prevent silent failures.

Previously, an unhandled error within the `updateFn` or `renderFn` would break the `requestAnimationFrame` chain, causing the game to freeze silently without any visible error. This change catches such errors, logs them to the console, gracefully stops the game loop, and dispatches a `GameLoopError` event, making debugging straightforward.