### PR TITLE
Exclude Vite build artifacts from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/.vite/
 
 # Production build output
 dist/
+
+# Exclude Vite optimized dependencies metadata
+node_modules/.vite/deps/


### PR DESCRIPTION
Exclude Vite-generated build artifacts from version control to prevent repository bloat and merge conflicts.