### PR TITLE
Fix retry logic in startLevel function

### DIFF
--- a/src/js/core/main.js
+++ b/src/js/core/main.js
@@ -46,8 +46,6 @@ let isInitialized = false;
 
 
 /* --- Retry guard to prevent infinite error loops between showLevelMenu and startLevel --- */
-const MAX_MENU_START_RETRIES = 3;
-let menuStartRetryCount = 0;
 const MAX_RETRY_ATTEMPTS = 3;
 const retryAttempts = { showLevelMenu: 0, startLevel: 0, initializeWelcomeScreen: 0 };
 
@@ -235,16 +233,22 @@ function startLevel(levelName) {
     currentLevel.start();
 
     console.log('✅ Level started successfully');
-    menuStartRetryCount = 0;
+    retryAttempts.startLevel = 0;
   } catch (error) {
     console.error('❌ Error starting level:', error);
-    menuStartRetryCount += 1;
-    if (menuStartRetryCount >= MAX_MENU_START_RETRIES) {
+    retryAttempts.startLevel += 1;
+    if (retryAttempts.startLevel >= MAX_RETRY_ATTEMPTS) {
       showFatalErrorScreen('Unable to start the level after multiple attempts.', error);
       return;
     }
     gameState = 'menu';
-    showLevelMenu();
+    
+    // Only call showLevelMenu if it hasn't already exceeded its retry limit
+    if (retryAttempts.showLevelMenu < MAX_RETRY_ATTEMPTS) {
+      showLevelMenu();
+    } else {
+      handleCriticalFailure('Unable to display the level menu after multiple attempts.');
+    }
   }
 }
 


### PR DESCRIPTION
Refactor `startLevel` retry logic to use the unified `retryAttempts` system and prevent infinite loops with `showLevelMenu`.

The `startLevel` function used an outdated, separate retry counter (`menuStartRetryCount`), making `resetRetryCounters()` ineffective for it and creating an inconsistent retry mechanism. Furthermore, it could call `showLevelMenu` upon failure without respecting `showLevelMenu`'s own retry limits, potentially leading to an infinite loop between the two functions. This PR aligns `startLevel` with the global retry system and adds a check to prevent this loop.